### PR TITLE
Fixed VS 2015 link

### DIFF
--- a/gameplay/multiplayer-server-setup.md
+++ b/gameplay/multiplayer-server-setup.md
@@ -156,7 +156,7 @@ We're now ready to start setting up the Rigs of Rods server.
 
 #### Required tools:
 
-- [VS 2015 Community Edition]( https://www.visualstudio.com/vs/community/) C++ tools must be installed: 
+- [VS 2015 Community Edition]( http://dl.rigsofrods.org/developer/vs_community__2015.exe) C++ tools must be installed: 
 
 ![vs](/images/VS-server-cplusplus.png)
 


### PR DESCRIPTION
Since Microsoft removed the download for Visual Studio 2015 Community Edition in favor of VS 2017, I've uploaded the VS 2015 online installer. It should still work.