### PR TITLE
Added `c` flag to commands section + fixed SC page links

### DIFF
--- a/vehicle-creation/fileformat-truck.md
+++ b/vehicle-creation/fileformat-truck.md
@@ -1089,8 +1089,9 @@ The commands section describes the "real" hydros, that is, those you command wit
 -   **Contraction key**: <span style="color:#BD0058">Function key code (decimal number)</span> A number representing the function key used to control the command beam. More than one can be controlled with the same key. (See below for the keymap.)
 -   **Extension key**: <span style="color:#BD0058">Function key code (decimal number)</span> The key used to extend the command beam.
 -   **Option flag** <span style="color:#666">(optional)</span>: <span style="color:#BD0058">Single character</span>
-    -   `i`: makes the command beam invisible.
-    -   `r`: makes the command behave like a rope or a winch (no compression strength).
+    -   `i`: Makes the command beam invisible.
+    -   `r`: Makes the command behave like a rope or a winch (no compression strength).
+	- 	`c`: Makes the command beam auto-center: It will automatically return it to its starting position when a lengthening/shortening key is released.
     -   `n`: Placeholder, does nothing (useful as filler when you need to specify description)
 -   **Description** <span style="color:#666">(optional)</span>: <span style="color:#BD0058">String</span> A text description that tells the user what the command beam does when the it is activated. This is shown by pressing `CTRL+T` ingame. There is no need to put a key in front of the text (like F1:\_do\_something) this will be done automatically! Writing "hide" will hide the command from the "t-screen".
 

--- a/vehicle-creation/special-components.md
+++ b/vehicle-creation/special-components.md
@@ -6,7 +6,7 @@ title: "Special components"
 
 # Command hydraulics - `commands`
 
-[Documentation](/technical/fileformat-truckfile#commands)
+[Documentation](/vehicle-creation/fileformat-truck/#commands)
 
 A&nbsp;command is a beam&nbsp; that has "Commands"&nbsp;that make it extend/retract and so forth, 
 The command beam has many uses, From being a Hydraulic arm to a destruction tool,
@@ -34,11 +34,11 @@ This is a guide how you can use the different connection methods in RoR.
 
 ## Ropables
 
-The documentation about ropables [can be found here](/technical/fileformat-truckfile#ropables)
+The documentation about ropables [can be found here](/vehicle-creation/fileformat-truck/#ropables)
 
 ## Ties
 
-The documentation about ties [can be found here](/technical/fileformat-truckfile#ties)
+The documentation about ties [can be found here](/vehicle-creation/fileformat-truck/#ties)
 
 Ties (as commands) can only work over an RPM of 800 and might request more power from the engine when being used.
 
@@ -46,7 +46,7 @@ So basically define a tie on the transport truck and a ropable on the load you w
 
 ## Hooks
 
-The documentation about hooks [can be found here](/technical/fileformat-truckfile#hooks)
+The documentation about hooks [can be found here](/vehicle-creation/fileformat-truck/#hooks)
 
 Hooks lock against nodes in a search area of 40 centimeters.
 

--- a/vehicle-creation/special-components.md
+++ b/vehicle-creation/special-components.md
@@ -21,8 +21,7 @@ Some of the things you can do with commands...
 
 One example (in picture below) - all of the moving parts are made by using Commands:
 
-[commands-wrecker]: /images/commands-example-t800-wrecker.jpg
-![commands-wrecker]
+![commands-wrecker](/images/commands-example-t800-wrecker.jpg)
 
 # Connection utilities
 


### PR DESCRIPTION
The `c` flag also works for standard commands, thanks to 4x4convoy for letting me know about this.
Also fixed the links on the special components page.