### PR TITLE
update link for templates

### DIFF
--- a/terrain-creation/terrain-conversion-terrn2.md
+++ b/terrain-creation/terrain-conversion-terrn2.md
@@ -30,7 +30,7 @@ WorldTexture=texture.dds
 This is the texture image for this single-layer. A majority of 0.3x terrains only use this layer for their terrain texture. Terrains that have more than one texture layer use [Alpha Splatting](/terrain-creation/custom-texture-splatting/) which is not covered in this tutorial.
 
 ## Getting the template
-I have made and uploaded a template terrain [here](https://forum.rigsofrods.org/threads/template-raw-png-terrains.112/) with the right file structure which will be used throughout this tutorial. 
+I have made and uploaded a template terrain [here](https://forum.rigsofrods.org/resources/template-raw-png-terrains.262/) with the right file structure which will be used throughout this tutorial. 
 Download the raw heightmap version, as 0.3x terrains use .raw heightmaps.
 
 


### PR DESCRIPTION
update to the link in line 33. The current link for the templates generates an error on the repository. New Link should now direct users to the correct page. 