### PR TITLE
Added developer wiki redirects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,7 @@ name: Rigs of Rods Documentation
 markdown: kramdown
 highlighter: rouge
 permalink: pretty
+
+# Plugins
+plugins:
+  - jekyll-redirect-from

--- a/_config_testing.yml
+++ b/_config_testing.yml
@@ -7,3 +7,8 @@ name: Local Rigs of Rods Documentation
 markdown: kramdown
 highlighter: rouge
 permalink: pretty
+
+# Plugins
+plugins:
+  - jekyll-redirect-from
+  

--- a/developer/coding-style.md
+++ b/developer/coding-style.md
@@ -1,0 +1,6 @@
+---
+layout: page
+title:  "Coding style"
+categories: [developer]
+redirect_to: "https://github.com/RigsOfRods/rigs-of-rods/wiki/Coding-style"
+---

--- a/developer/commit-style.md
+++ b/developer/commit-style.md
@@ -1,0 +1,6 @@
+---
+layout: page
+title:  "Commit style"
+categories: [developer]
+redirect_to: "https://github.com/RigsOfRods/rigs-of-rods/wiki/Commit-style"
+---

--- a/developer/compile-linux.md
+++ b/developer/compile-linux.md
@@ -1,0 +1,6 @@
+---
+layout: page
+title:  "Compile (Linux)"
+categories: [developer]
+redirect_to: "https://github.com/RigsOfRods/rigs-of-rods/wiki/Compile-(Linux)"
+---

--- a/developer/compile-windows.md
+++ b/developer/compile-windows.md
@@ -1,0 +1,6 @@
+---
+layout: page
+title:  "Compile (Windows)"
+categories: [developer]
+redirect_to: "https://github.com/RigsOfRods/rigs-of-rods/wiki/Compile-(Windows)"
+---


### PR DESCRIPTION
Added 4 pages to the "For developers" category that redirect using `jekyll-redirect-from` to their appropriate GitHub wiki pages. 
Seems to work fine locally, but I'll wait for @only-a-ptr to test. 