### PR TITLE
Use dark theme based on OS preference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ theme:
   favicon: ror-favicon.png
   logo: images/branding/RoR_Logo_TT.png
   palette:
+    scheme: preference
     primary: "blue"
     accent: "blue"
   features:


### PR DESCRIPTION
This will automatically set the color scheme to dark based on OS preference. Added in mkdocs-material 5.3.0. (See https://github.com/squidfunk/mkdocs-material/issues/1266 for more info)
![Screenshot_2020-06-15 Truck file format - Rigs of Rods documentation](https://user-images.githubusercontent.com/46073351/84678876-900e3d80-aefe-11ea-8956-0a21ce7f2e1b.png)
