### PR TITLE
Force dark mode

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ theme:
     favicon: ror-favicon.png
     logo: images/branding/RoR_Logo_TT.png
     palette:
-        scheme: preference
+        scheme: slate
         primary: "blue"
         accent: "blue"
     features:


### PR DESCRIPTION
This should fix an issue where material ui detects the host's color preferences (dark or light) and causes this: 
![image](https://user-images.githubusercontent.com/4823878/109059277-5ecc4b00-76e4-11eb-8849-1305b087a1a4.png)

Solution: Force dark mode to material ui.
P.S: all of these are temporary solution (including the recoloring etc) I will be making an mkdocs theme exclusive to RoR based on the upcoming site design, using tailwind css (long story short: pure css, not frameworks).